### PR TITLE
Only commit to the main-out branch when there are changes

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -62,8 +62,16 @@ jobs:
         cd data
         git log HEAD --pretty=format:"${{ env.COMMIT_FORMAT }}" -1 > ../commitMsg.txt
         cd ../gen
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git add .
-        git commit -F ../commitMsg.txt
-        git push
+        if [[ `git status --porcelain` ]]; then
+          # Changes, use git status to add to log file for debugging.
+          echo Changes detected, committing.
+          git status --short
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -F ../commitMsg.txt
+          git push
+        else
+          # No changes
+          echo No changes
+        fi


### PR DESCRIPTION
When a commit is made to `main` that does not change the generated CLDR data, the github workflow fails while trying to commit. [Job, step 9](https://github.com/nvaccess/nvda-cldr/actions/runs/3049868629/jobs/4916373196#step:9:1)

``` 
Commit and push
Run pwd
/home/runner/work/nvda-cldr/nvda-cldr
On branch main-out
Your branch is up to date with 'origin/main-out'.

nothing to commit, working tree clean
Error: Process completed with exit code
```


Test for changed files and make the commit explicit: