### PR TITLE
Inherit symbol level for languages other than English

### DIFF
--- a/build.py
+++ b/build.py
@@ -29,7 +29,8 @@ PathT = str
 
 def createCLDRAnnotationsDict(
 	sources: Iterable[PathT],
-	dest: PathT
+	dest: PathT,
+	level: str,
 ) -> None:
 	"""Produce NVDA dict file based on CLDR annotations.
 	"""
@@ -47,10 +48,8 @@ def createCLDRAnnotationsDict(
 	with codecs.open(dest, "w", "utf_8_sig", errors="replace") as dictFile:
 		dictFile.write(u"symbols:\r\n")
 		for pattern, description in cldrDict.items():
-			# Punctuations are set to none for CLDR characters to be pronounced
-			# even if user set punctuation level to None
 			dictFile.write(
-				f"{pattern}\t{description}\tnone\r\n"
+				f"{pattern}\t{description}\t{level}\r\n"
 			)
 
 
@@ -174,7 +173,14 @@ def createLocalesFromCldr(outDir: PathT) -> None:
 		os.makedirs(localeOutDir)
 		assert os.path.isdir(localeOutDir), f"Locale output dir must exist: {localeOutDir}"
 		outFile = os.path.join(localeOutDir, "cldr.dic")
-		createCLDRAnnotationsDict(cldrSources, outFile)
+		if destLocale == "en":
+			# For English (the default fallback), punctuations are set to none for CLDR characters to be pronounced
+			# even if user set punctuation level to None
+			level = 'none'
+		else:
+			# For other languages the level is set to be inherited from English symbol file or English CLDR file.
+			level = '-'
+		createCLDRAnnotationsDict(cldrSources, outFile, level)
 
 
 def main():


### PR DESCRIPTION
### Link to issue number:
Fixes https://github.com/nvaccess/nvda/issues/14417
### Summary of the issue:

Hindi has no symbol defined in its symbol file, only copyright header; seems that the file was prepared for translation but no actual symbol translation took place.
But there is a Hindi CLDR file. Thus the symbol level for symbols such as common punctuation (dot, question marke, etc.) is the one of CLDR, i.e. none.

This is not adapted and it would be better to take advantage of the symbol levels that are defined in the English symbol file.

### Description of user facing changes

In NVDA, locale CLDR dic file inherits symbol levels from the files coming after, i.e. English symbols and English CLDR. In case the locale symbol file does not define a character's level, this allows to:
1. Use the level for this symbol if it is defined there
2. Use "none" (coming from English CLDR dic file) if the character is not defined in English symbol file but is defined in CLDR.

### Description of development approach
* For all languages except English ("en"), generate the `cldr.dic` file with "-" in the level field, meaning that the level is inherited from previous files.
* For English `cldr.dic` file, use "none" for the symbol level, as it was already before this PR.

### Testing strategy:
Manual tests:
* Generate `cldr.dic` files with:
  `py -3.7-32 build.py`
* Copy all these files in NVDA sources
* Removed all the French symbol file content except commented header lines (better for me to test in French than in Hindi)
* Checked that symbols are reported in French at higher punctuation levels
* Also checked that I do not hear English punctuation when reading Hindi example in https://github.com/nvaccess/nvda/issues/14417

### Known issues with pull request:

* Hindi CLDR file seems to define the punctuation names as said in English, but written with Hindi alphabet. I do not know if it is common or not when reading Hindi. Anyway, the content of Hindi CLDR file or of the Hindi symbol file is out-of-scope of this PR.
* This PR fixes the issue on nvda-cldr side. When this PR is merged, I will still have to make another PR against nvda to use the new commit of this repo.
* There are other issues in the case the locale symbol file is not only empty but totally missing. This is out-of-scope of this PR and should be fixed on nvda side. I also plan to do this.

### Change log entries:
N/A in this repo.

### Code Review Checklist:

It rather applies to nvda's repo, but I keep it here in case these checks are found useful.

- [x] Pull Request description:
  - description is up to date
  - change log entries
- [x] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [x] API is compatible with existing add-ons.
- [x] Documentation:
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [x] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [x] Security precautions taken.
