### PR TITLE
Update CLDR to 48.2

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -16,7 +16,7 @@ jobs:
       COMMIT_FORMAT: "Generated from %h%n%nCommit message:%n%s%n%b"
     strategy:
       matrix:
-        python-version: [ 3.13.12 ]
+        python-version: [ 3.13 ]
     steps:
     - name: Current dir
       run: |

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -16,7 +16,7 @@ jobs:
       COMMIT_FORMAT: "Generated from %h%n%nCommit message:%n%s%n%b"
     strategy:
       matrix:
-        python-version: [ 3.11 ]
+        python-version: [ 3.13.12 ]
     steps:
     - name: Current dir
       run: |

--- a/readme.md
+++ b/readme.md
@@ -7,12 +7,12 @@ the `source/locale/*/cldr.dic` files, from CLDR data.
 
 
 ## Requirements
-- Python 3.11-32
+- Python 3.13-64
   - Intention: Match the NVDA python version, reduce tooling complexity for developers. 
 
 ## Run
 1. Ensure the output directory is empty or non-existent.
-1. `py -3.7-32` build.py
+1. `py -3.13-64` build.py
 
 ## Output
 See `out\` directory.


### PR DESCRIPTION
This pull request updates the CLDR submodule to version 48.2. Additionally, the GitHub Actions script changes the Python version to 3.13.12 (the same as NVDA's version).

No new locale changes were found in 48.1 and 48.2.